### PR TITLE
Document CODEOWNERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ follow the below instructions:
 1. Click **Create repository**
 1. Clone your new repository
 
+> [!CAUTION]
+>
+> Make sure to remove or update the [`CODEOWNERS`](./CODEOWNERS) file! For
+> details on how to use this file, see
+> [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+
 ## Initial Setup
 
 After you've cloned the repository to your local machine or codespace, you'll


### PR DESCRIPTION
This PR adds a call out in the README that the CODEOWNERS file should be removed or modified when the template repo is copied.